### PR TITLE
Handle ValueError for badly formed JWT

### DIFF
--- a/oidc_auth/authentication.py
+++ b/oidc_auth/authentication.py
@@ -122,7 +122,7 @@ class JSONWebTokenAuthentication(BaseOidcAuthentication):
         keys = self.jwks()
         try:
             id_token = JWS().verify_compact(jwt_value, keys=keys)
-        except JWKESTException:
+        except (JWKESTException, ValueError):
             msg = _('Invalid Authorization header. JWT Signature verification failed.')
             raise AuthenticationFailed(msg)
 


### PR DESCRIPTION
If you pass `Authorization: JWT XXX.xxx.xxx` then ValueError from JSON decode would be raised, which isn't handled by this library and goes upwards instead of giving authentication error.