### PR TITLE
Add support for conafigurable userinfo_endpoint and a better error handling when this is missing

### DIFF
--- a/oidc_auth/authentication.py
+++ b/oidc_auth/authentication.py
@@ -69,8 +69,9 @@ class BearerTokenAuthentication(BaseOidcAuthentication):
     @cache(ttl=api_settings.OIDC_BEARER_TOKEN_EXPIRATION_TIME)
     def get_userinfo(self, token):
         userinfo_endpoint = self.oidc_config.get('userinfo_endpoint', api_settings.USERINFO_ENDPOINT)
-        if userinfo_endpoint in ['', None, [], (), {}]:
-            msg = _('Invalid userinfo_endpoint URL. Not found an URL from OpenID connect discovery metadata nor settings.OIDC_AUTH.USERINFO_ENDPOINT.')
+        if not userinfo_endpoint:
+            msg = _('Invalid userinfo_endpoint URL.'
+                    'Not found an URL from OpenID connect discovery metadata nor settings.OIDC_AUTH.USERINFO_ENDPOINT.')
             raise AuthenticationFailed(msg)
         response = requests.get(userinfo_endpoint,
                                 headers={'Authorization': 'Bearer {0}'.format(token.decode('ascii'))})

--- a/oidc_auth/authentication.py
+++ b/oidc_auth/authentication.py
@@ -68,7 +68,11 @@ class BearerTokenAuthentication(BaseOidcAuthentication):
 
     @cache(ttl=api_settings.OIDC_BEARER_TOKEN_EXPIRATION_TIME)
     def get_userinfo(self, token):
-        response = requests.get(self.oidc_config['userinfo_endpoint'],
+        userinfo_endpoint = self.oidc_config.get('userinfo_endpoint', api_settings.USERINFO_ENDPOINT)
+        if userinfo_endpoint in ['', None, [], (), {}]:
+            msg = _('Invalid userinfo_endpoint URL. Not found an URL from OpenID connect discovery metadata nor settings.OIDC_AUTH.USERINFO_ENDPOINT.')
+            raise AuthenticationFailed(msg)
+        response = requests.get(userinfo_endpoint,
                                 headers={'Authorization': 'Bearer {0}'.format(token.decode('ascii'))})
         response.raise_for_status()
 

--- a/oidc_auth/settings.py
+++ b/oidc_auth/settings.py
@@ -23,6 +23,9 @@ DEFAULTS = {
 
     'JWT_AUTH_HEADER_PREFIX': 'JWT',
     'BEARER_AUTH_HEADER_PREFIX': 'Bearer',
+
+    # URL of the OpenID Provider's UserInfo Endpoint
+    'USERINFO_ENDPOINT': None,
 }
 
 # List of settings that may be in string import notation.

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    {py27,py34}-django{18,19,110}-drf{32}
+    {py27,py34,py35,py36}-django{18,19,110}-drf{32,33,34,35,36}
 
 [testenv]
 commands =
@@ -12,6 +12,11 @@ setenv =
 deps =
     django18: Django==1.8.4
     django19: Django==1.9.12
-    django110: Django==1.10.4
-    drf32: djangorestframework==3.2.4
+    django110: Django==1.10.6
+    drf32: djangorestframework==3.2.5
+    drf33: djangorestframework==3.3.3
+    drf34: djangorestframework==3.4.7
+    drf35: djangorestframework==3.5.4
+    drf36: djangorestframework==3.6.2
     py27: mock
+    ipdb


### PR DESCRIPTION
Add support for configurable userinfo_endpoint and a better error handling when OpenID connect provider discovery metadata does not contain this field.