### PR TITLE
Do not check azp against OIDC_AUDIENCES

### DIFF
--- a/oidc_auth/authentication.py
+++ b/oidc_auth/authentication.py
@@ -145,9 +145,6 @@ class JSONWebTokenAuthentication(BaseOidcAuthentication):
         if len(id_token['aud']) > 1 and 'azp' not in id_token:
             msg = _('Invalid Authorization header. Missing JWT authorized party.')
             raise AuthenticationFailed(msg)
-        if 'azp' in id_token and id_token['azp'] not in api_settings.OIDC_AUDIENCES:
-            msg = _('Invalid Authorization header. Invalid JWT authorized party.')
-            raise AuthenticationFailed(msg)
 
         utc_timestamp = timegm(datetime.datetime.utcnow().utctimetuple())
         if utc_timestamp > id_token.get('exp', 0):


### PR DESCRIPTION
The Authorized Party (azp) field should contain the Client ID of the
party to which the ID Token was issued. [1] It's responsibility of
the *client* to check the azp and since we're not an OIDC client here,
but rather acting as a resource server, we shouldn't care about azp.

This is important for use cases where OpenID provider issues an ID token
for an application (= relying party, RP) which then authenticates
itself to the resource server (RS) with the same ID token.  In that case
the "aud" field of the ID token should contain RP and RS and "azp" field
should contain RP.

[1] http://openid.net/specs/openid-connect-core-1_0.html#IDToken