### PR TITLE
Caching the oidc configuration with the cache object instead cached_property

### DIFF
--- a/oidc_auth/authentication.py
+++ b/oidc_auth/authentication.py
@@ -27,7 +27,8 @@ def get_user_by_id(request, id_token):
 
 
 class BaseOidcAuthentication(BaseAuthentication):
-    @cached_property
+    @property
+    @cache(ttl=api_settings.OIDC_BEARER_TOKEN_EXPIRATION_TIME)
     def oidc_config(self):
         return requests.get(api_settings.OIDC_ENDPOINT + '/.well-known/openid-configuration').json()
 


### PR DESCRIPTION
There is a small bug (in my opinion), the .well-known/openid-configuration request should be cached beyond the instance, since every request will have a new instance of the BaseOidcAuthentication and thus it will do the request to the auth server every time.

This change prevents that and makes it behave similar to the call to /jwks