### PR TITLE
 Use the built-in Django cache instead of a bespoke one

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ OIDC_AUTH = {
     
     # (Optional) Token prefix in Bearer authorization header (default 'Bearer')
     'BEARER_AUTH_HEADER_PREFIX': 'Bearer',
+
+    # (Optional) Which Django cache to use
+    'OIDC_CACHE_NAME': 'default',
+
+    # (Optional) A cache key prefix when storing and retrieving cached values
+    'OIDC_CACHE_PREFIX': 'oidc_auth.',
 }
 ```
 

--- a/oidc_auth/authentication.py
+++ b/oidc_auth/authentication.py
@@ -118,10 +118,8 @@ class JSONWebTokenAuthentication(BaseOidcAuthentication):
     @cache(ttl=api_settings.OIDC_JWKS_EXPIRATION_TIME)
     def jwks_data(self):
         r = request("GET", self.oidc_config['jwks_uri'], allow_redirects=True)
-        if r.status_code == 200:
-            return r.text
-        else:
-            raise Exception("HTTP Get error: %s" % r.status_code)
+        r.raise_for_status()
+        return r.text
 
     @cached_property
     def issuer(self):

--- a/oidc_auth/settings.py
+++ b/oidc_auth/settings.py
@@ -23,6 +23,10 @@ DEFAULTS = {
 
     'JWT_AUTH_HEADER_PREFIX': 'JWT',
     'BEARER_AUTH_HEADER_PREFIX': 'Bearer',
+
+    # The Django cache to use
+    'OIDC_CACHE_NAME': 'default',
+    'OIDC_CACHE_PREFIX': 'oidc_auth.'
 }
 
 # List of settings that may be in string import notation.

--- a/oidc_auth/util.py
+++ b/oidc_auth/util.py
@@ -6,11 +6,15 @@ from .settings import api_settings
 
 class cache(object):
     """ Cache decorator that memoizes the return value of a method for some time.
-    """
-    cache_version = 1
 
-    def __init__(self, ttl):
+    Increment the cache_version everytime your method's implementation changes in such a way that it returns values
+    that are not backwards compatible. For more information, see the Django cache documentation:
+    https://docs.djangoproject.com/en/2.2/topics/cache/#cache-versioning
+    """
+
+    def __init__(self, ttl, cache_version=1):
         self.ttl = ttl
+        self.cache_version = cache_version
 
     def __call__(self, fn):
         @functools.wraps(fn)

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -101,8 +101,8 @@ class AuthenticationTestCase(TestCase):
         self.mock_get.side_effect = self.responder.get
         keys = KEYS()
         keys.add({'key': key, 'kty': 'RSA', 'kid': key.kid})
-        self.patch('jwkest.jwk.request', return_value=Mock(status_code=200,
-                                                           text=keys.dump_jwks()))
+        self.patch('oidc_auth.authentication.request', return_value=Mock(status_code=200,
+                                                                         text=keys.dump_jwks()))
 
 
 class TestBearerAuthentication(AuthenticationTestCase):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,6 +1,13 @@
 from random import random
 from unittest import TestCase
+
+from oidc_auth.settings import api_settings
 from oidc_auth.util import cache
+
+try:
+    from unittest.mock import patch, Mock, ANY
+except ImportError:
+    from mock import patch, Mock, ANY
 
 
 class TestCacheDecorator(TestCase):
@@ -39,3 +46,37 @@ class TestCacheDecorator(TestCase):
     def test_that_cache_can_store_None(self):
         self.assertIsNone(self.return_none())
         self.assertIsNone(self.return_none())
+
+    @patch('oidc_auth.util.caches')
+    def test_uses_django_cache_uncached(self, caches):
+        caches['default'].get.return_value = None
+        self.mymethod()
+        caches['default'].get.assert_called_with('oidc_auth.mymethod', version=1)
+        caches['default'].set.assert_called_with('oidc_auth.mymethod', ANY, timeout=1, version=1)
+
+    @patch('oidc_auth.util.caches')
+    def test_uses_django_cache_cached(self, caches):
+        return_value = random()
+        caches['default'].get.return_value = return_value
+        self.assertEqual(return_value, self.mymethod())
+        caches['default'].get.assert_called_with('oidc_auth.mymethod', version=1)
+        self.assertFalse(caches['default'].set.called)
+
+    @patch.object(api_settings, 'OIDC_CACHE_NAME', 'other')
+    def test_respects_cache_name(self):
+        caches = {
+            'default': Mock(),
+            'other': Mock(),
+        }
+        with patch('oidc_auth.util.caches', caches):
+            self.mymethod()
+            self.assertTrue(caches['other'].get.called)
+            self.assertFalse(caches['default'].get.called)
+
+    @patch.object(api_settings, 'OIDC_CACHE_PREFIX', 'some-other-prefix.')
+    @patch('oidc_auth.util.caches')
+    def test_respects_cache_prefix(self, caches):
+        caches['default'].get.return_value = None
+        self.mymethod()
+        caches['default'].get.assert_called_once_with('some-other-prefix.mymethod', version=1)
+        caches['default'].set.assert_called_once_with('some-other-prefix.mymethod', ANY, timeout=1, version=1)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -39,21 +39,3 @@ class TestCacheDecorator(TestCase):
     def test_that_cache_can_store_None(self):
         self.assertIsNone(self.return_none())
         self.assertIsNone(self.return_none())
-
-    def test_that_expiration_works_as_expected(self):
-        c = cache(10)
-        c.add_to_cache(('abcde',), 'one', 5)
-        c.add_to_cache(('fghij',), 'two', 6)
-        c.add_to_cache(('klmno',), 'three', 7)
-        self.assertEqual(c.get_from_cache(('abcde',)), 'one')
-        self.assertEqual(c.get_from_cache(('fghij',)), 'two')
-        self.assertEqual(c.get_from_cache(('klmno',)), 'three')
-        c.purge_expired(14)
-        self.assertEqual(c.get_from_cache(('abcde',)), 'one')
-        c.purge_expired(16)
-        self.assertRaises(KeyError, c.get_from_cache, ('abcde',))
-        self.assertEqual(c.get_from_cache(('fghij',)), 'two')
-
-        c.purge_expired(20)
-        self.assertRaises(KeyError, c.get_from_cache, ('fghij',))
-        self.assertRaises(KeyError, c.get_from_cache, ('klmno',))


### PR DESCRIPTION
The previous implementation had a race condition if fn() took non-negligable amount of time and the cache-decorated function was called multiple times in quick succession (e.g. if a client makes multiple requests for resources that require a userinfo lookup.

Instead of improving the existing implementation, this replaces it with an implementation backed by Django's cache framework, which should also provide more flexibility.

If the application doesn't have a cache configured, Django will use an LRU in-memory cache which respects timeouts, which will provide similar behaviour to the previous implementation.