### PR TITLE
Update travis pip tox venv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ python:
   - 3.6
   - 3.7
 install:
-  - pip install tox tox-travis
+  - pip install -U tox tox-travis pip virtualenv
 script:
   - tox


### PR DESCRIPTION
Update travis pip, tox and venv. Tests were failing because cryptography could not be installed for some envs because it could not find Rust compiler (which was due to an outdated venv etc.)