### PR TITLE
Move authentication test case to module

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,34 @@ pip install tox
 tox
 ```
 
+## Mocking authentication
+
+There's a `AuthenticationTestCaseMixin` provided in the `oidc_auth.test` module, which you 
+can use for testing authentication like so:
+```python
+from oidc_auth.test import AuthenticationTestCaseMixin
+from django.test import TestCase
+
+class MyTestCase(AuthenticationTestCaseMixin, TestCase):
+    def test_example_cache_of_valid_bearer_token(self):
+        self.responder.set_response(
+            'http://example.com/userinfo', {'sub': self.user.username})
+        auth = 'Bearer egergerg'
+        resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
+        self.assertEqual(resp.status_code, 200)
+
+        # Token expires, but validity is cached
+        self.responder.set_response('http://example.com/userinfo', "", 401)
+        resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
+        self.assertEqual(resp.status_code, 200)
+
+    def test_example_using_invalid_bearer_token(self):
+        self.responder.set_response('http://example.com/userinfo', "", 401)
+        auth = 'Bearer hjikasdf'
+        resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
+        self.assertEqual(resp.status_code, 401)
+```
+
 # References
 
 * Requires [Django REST Framework](http://www.django-rest-framework.org/)

--- a/oidc_auth/test.py
+++ b/oidc_auth/test.py
@@ -1,0 +1,82 @@
+import json
+from django.contrib.auth import get_user_model
+from requests.models import Response
+from authlib.jose import JsonWebToken, KeySet, RSAKey
+try:
+    from unittest.mock import patch, Mock
+except ImportError:
+    from mock import patch, Mock
+
+key = RSAKey.generate_key(is_private=True)
+
+
+def make_id_token(sub,
+                  iss='http://example.com',
+                  aud='you',
+                  exp=999999999999,  # tests will start failing in September 33658
+                  iat=999999999999,
+                  **kwargs):
+    return make_jwt(
+        dict(
+            iss=iss,
+            aud=aud,
+            exp=exp,
+            iat=iat,
+            sub=str(sub),
+            **kwargs
+        )
+    ).decode('ascii')
+
+
+def make_jwt(payload):
+    jwt = JsonWebToken(['RS256'])
+    jws = jwt.encode(
+        {'alg': 'RS256', 'kid': key.as_dict(add_kid=True).get('kid')}, payload, key=key)
+    return jws
+
+
+class FakeRequests(object):
+    def __init__(self):
+        self.responses = {}
+
+    def set_response(self, url, content, status_code=200):
+        self.responses[url] = (status_code, json.dumps(content))
+
+    def get(self, url, *args, **kwargs):
+        wanted_response = self.responses.get(url)
+        if not wanted_response:
+            status_code, content = 404, ''
+        else:
+            status_code, content = wanted_response
+
+        response = Response()
+        response._content = content.encode('utf-8')
+        response.status_code = status_code
+
+        return response
+
+
+class AuthenticationTestCaseMixin(object):
+    def patch(self, thing_to_mock, **kwargs):
+        patcher = patch(thing_to_mock, **kwargs)
+        patched = patcher.start()
+        self.addCleanup(patcher.stop)
+        return patched
+
+    def setUp(self):
+        self.user, _ = get_user_model().objects.get_or_create(username='henk')
+        self.responder = FakeRequests()
+        self.responder.set_response("http://example.com/.well-known/openid-configuration",
+                                    {"jwks_uri": "http://example.com/jwks",
+                                     "issuer": "http://example.com",
+                                     "userinfo_endpoint": "http://example.com/userinfo"})
+        self.mock_get = self.patch('requests.get')
+        self.mock_get.side_effect = self.responder.get
+        keys = KeySet(keys=[key])
+        self.patch(
+            'oidc_auth.authentication.request',
+            return_value=Mock(
+                status_code=200,
+                json=keys.as_json
+            )
+        )

--- a/oidc_auth/test.py
+++ b/oidc_auth/test.py
@@ -57,6 +57,8 @@ class FakeRequests(object):
 
 
 class AuthenticationTestCaseMixin(object):
+    username = 'henk'
+
     def patch(self, thing_to_mock, **kwargs):
         patcher = patch(thing_to_mock, **kwargs)
         patched = patcher.start()
@@ -64,7 +66,7 @@ class AuthenticationTestCaseMixin(object):
         return patched
 
     def setUp(self):
-        self.user, _ = get_user_model().objects.get_or_create(username='henk')
+        self.user, _ = get_user_model().objects.get_or_create(username=self.username)
         self.responder = FakeRequests()
         self.responder.set_response("http://example.com/.well-known/openid-configuration",
                                     {"jwks_uri": "http://example.com/jwks",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='drf-oidc-auth',
-    version='2.0.0',
+    version='2.0.1',
     packages=['oidc_auth'],
     url='https://github.com/ByteInternet/drf-oidc-auth',
     license='MIT',

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -1,28 +1,26 @@
-import json
 import sys
 
+from authlib.jose.errors import BadSignatureError, DecodeError
 from django.conf.urls import url
-from django.contrib.auth.models import User
 from django.http import HttpResponse
 from django.test import TestCase
-from requests import Response
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.views import APIView
 
-from authlib.jose import JsonWebToken, KeySet, RSAKey
-from authlib.jose.errors import BadSignatureError, DecodeError
 from oidc_auth.authentication import (BearerTokenAuthentication,
                                       JSONWebTokenAuthentication)
+from oidc_auth.test import make_id_token, AuthenticationTestCaseMixin
 
 if sys.version_info > (3,):
     long = int
 else:
     class ConnectionError(OSError):
         pass
+
 try:
-    from unittest.mock import patch, Mock
+    from unittest.mock import patch
 except ImportError:
-    from mock import patch, Mock
+    from mock import patch
 
 
 class MockView(APIView):
@@ -40,84 +38,10 @@ urlpatterns = [
     url(r'^test/$', MockView.as_view(), name="testview")
 ]
 
-key = RSAKey.generate_key(is_private=True)
 
-
-def make_jwt(payload):
-    jwt = JsonWebToken(['RS256'])
-    jws = jwt.encode(
-        {'alg': 'RS256', 'kid': key.as_dict(add_kid=True).get('kid')}, payload, key=key)
-    return jws
-
-
-def make_id_token(sub,
-                  iss='http://example.com',
-                  aud='you',
-                  exp=999999999999,  # tests will start failing in September 33658
-                  iat=999999999999,
-                  **kwargs):
-    return make_jwt(
-        dict(
-            iss=iss,
-            aud=aud,
-            exp=exp,
-            iat=iat,
-            sub=str(sub),
-            **kwargs
-        )
-    ).decode('ascii')
-
-
-class FakeRequests(object):
-    def __init__(self):
-        self.responses = {}
-
-    def set_response(self, url, content, status_code=200):
-        self.responses[url] = (status_code, json.dumps(content))
-
-    def get(self, url, *args, **kwargs):
-        wanted_response = self.responses.get(url)
-        if not wanted_response:
-            status_code, content = 404, ''
-        else:
-            status_code, content = wanted_response
-
-        response = Response()
-        response._content = content.encode('utf-8')
-        response.status_code = status_code
-
-        return response
-
-
-class AuthenticationTestCase(TestCase):
+class TestBearerAuthentication(AuthenticationTestCaseMixin, TestCase):
     urls = __name__
 
-    def patch(self, thing_to_mock, **kwargs):
-        patcher = patch(thing_to_mock, **kwargs)
-        patched = patcher.start()
-        self.addCleanup(patcher.stop)
-        return patched
-
-    def setUp(self):
-        self.user = User.objects.create(username='henk')
-        self.responder = FakeRequests()
-        self.responder.set_response("http://example.com/.well-known/openid-configuration",
-                                    {"jwks_uri": "http://example.com/jwks",
-                                     "issuer": "http://example.com",
-                                     "userinfo_endpoint": "http://example.com/userinfo"})
-        self.mock_get = self.patch('requests.get')
-        self.mock_get.side_effect = self.responder.get
-        keys = KeySet(keys=[key])
-        self.patch(
-            'oidc_auth.authentication.request',
-            return_value=Mock(
-                status_code=200,
-                json=keys.as_json
-            )
-        )
-
-
-class TestBearerAuthentication(AuthenticationTestCase):
     def test_using_valid_bearer_token(self):
         self.responder.set_response(
             'http://example.com/userinfo', {'sub': self.user.username})
@@ -175,7 +99,9 @@ class TestBearerAuthentication(AuthenticationTestCase):
         self.assertEqual(resp.status_code, 401)
 
 
-class TestJWTAuthentication(AuthenticationTestCase):
+class TestJWTAuthentication(AuthenticationTestCaseMixin, TestCase):
+    urls = __name__
+
     def test_using_valid_jwt(self):
         auth = 'JWT ' + make_id_token(self.user.username)
         resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
@@ -208,7 +134,7 @@ class TestJWTAuthentication(AuthenticationTestCase):
 
     def test_with_invalid_issuer(self):
         auth = 'JWT ' + \
-            make_id_token(self.user.username, iss='http://something.com')
+               make_id_token(self.user.username, iss='http://something.com')
         resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
         self.assertEqual(resp.status_code, 401)
 
@@ -239,7 +165,7 @@ class TestJWTAuthentication(AuthenticationTestCase):
 
     def test_with_multiple_audiences_and_authorized_party(self):
         auth = 'JWT ' + \
-            make_id_token(self.user.username, aud=['you', 'me'], azp='you')
+               make_id_token(self.user.username, aud=['you', 'me'], azp='you')
         resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
         self.assertEqual(resp.status_code, 200)
 


### PR DESCRIPTION
Move `AuthenticationTestCase` inside of `oidc_auth` module so other parties can make use of the functions defined in there (i.e. for integration testing/mocking authentication). Renamed to `AuthenticationTestCaseMixin` and made it a mixin so it can easily be used. Also updated README with an example on how to use the mixin.