### PR TITLE
Add configurable user endpoint

### DIFF
--- a/oidc_auth/authentication.py
+++ b/oidc_auth/authentication.py
@@ -97,13 +97,13 @@ class BearerTokenAuthentication(BaseOidcAuthentication):
 
     @cache(ttl=api_settings.OIDC_BEARER_TOKEN_EXPIRATION_TIME)
     def get_userinfo(self, token):
-        response = requests.get(
-            self.oidc_config['userinfo_endpoint'],
-            headers={'Authorization': 'Bearer {0}'.format(
-                token.decode('ascii')
-            )
-            }
-        )
+        userinfo_endpoint = self.oidc_config.get('userinfo_endpoint', api_settings.USERINFO_ENDPOINT)
+        if not userinfo_endpoint:
+            raise AuthenticationFailed(_('Invalid userinfo_endpoint URL. Did not find a URL from OpenID connect '
+                                         'discovery metadata nor settings.OIDC_AUTH.USERINFO_ENDPOINT.'))
+
+        response = requests.get(userinfo_endpoint, headers={
+            'Authorization': 'Bearer {0}'.format(token.decode('ascii'))})
         response.raise_for_status()
 
         return response.json()

--- a/oidc_auth/settings.py
+++ b/oidc_auth/settings.py
@@ -34,9 +34,10 @@ DEFAULTS = {
 
     # The Django cache to use
     'OIDC_CACHE_NAME': 'default',
-    'OIDC_CACHE_PREFIX': 'oidc_auth.'
+    'OIDC_CACHE_PREFIX': 'oidc_auth.',
 
-
+    # URL of the OpenID Provider's UserInfo Endpoint
+    'USERINFO_ENDPOINT': None,
 }
 
 # List of settings that may be in string import notation.

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -4,6 +4,7 @@ from authlib.jose.errors import BadSignatureError, DecodeError
 from django.conf.urls import url
 from django.http import HttpResponse
 from django.test import TestCase
+from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.views import APIView
 
@@ -18,9 +19,9 @@ else:
         pass
 
 try:
-    from unittest.mock import patch
+    from unittest.mock import patch, Mock, PropertyMock
 except ImportError:
-    from mock import patch
+    from mock import patch, Mock, PropertyMock
 
 
 class MockView(APIView):
@@ -41,6 +42,25 @@ urlpatterns = [
 
 class TestBearerAuthentication(AuthenticationTestCaseMixin, TestCase):
     urls = __name__
+
+    def setUp(self):
+        super(TestBearerAuthentication, self).setUp()
+        self.openid_configuration = {
+            'issuer': 'http://accounts.example.com/dex',
+            'authorization_endpoint': 'http://accounts.example.com/dex/auth',
+            'token_endpoint': 'http://accounts.example.com/dex/token',
+            'jwks_uri': 'http://accounts.example.com/dex/keys',
+            'response_types_supported': ['code'],
+            'subject_types_supported': ['public'],
+            'id_token_signing_alg_values_supported': ['RS256'],
+            'scopes_supported': ['openid', 'email', 'groups', 'profile', 'offline_access'],
+            'token_endpoint_auth_methods_supported': ['client_secret_basic'],
+            'claims_supported': [
+                'aud', 'email', 'email_verified', 'exp', 'iat', 'iss', 'locale',
+                'name', 'sub'
+            ],
+            'userinfo_endpoint': 'http://sellers.example.com/v1/sellers/'
+        }
 
     def test_using_valid_bearer_token(self):
         self.responder.set_response(
@@ -97,6 +117,25 @@ class TestBearerAuthentication(AuthenticationTestCaseMixin, TestCase):
         auth = 'Bearer'
         resp = self.client.get('/test/', HTTP_AUTHORIZATION=auth)
         self.assertEqual(resp.status_code, 401)
+
+    def test_get_user_info_endpoint(self):
+        with patch('oidc_auth.authentication.BaseOidcAuthentication.oidc_config', new_callable=PropertyMock) as oidc_config_mock:
+            oidc_config_mock.return_value = self.openid_configuration
+            authentication = BearerTokenAuthentication()
+            response_mock = Mock(return_value=Mock(status_code=200,
+                                                   json=Mock(return_value={}),
+                                                   raise_for_status=Mock(return_value=None)))
+            with patch('oidc_auth.authentication.requests.get', response_mock):
+                result = authentication.get_userinfo(b'token')
+                assert result == {}
+
+    def test_get_user_info_endpoint_with_missing_field(self):
+        self.openid_configuration.pop('userinfo_endpoint')
+        with patch('oidc_auth.authentication.BaseOidcAuthentication.oidc_config', new_callable=PropertyMock) as oidc_config_mock:
+            oidc_config_mock.return_value = self.openid_configuration
+            authentication = BearerTokenAuthentication()
+            with self.assertRaisesMessage(AuthenticationFailed, 'userinfo_endpoint'):
+                authentication.get_userinfo(b'faketoken')
 
 
 class TestJWTAuthentication(AuthenticationTestCaseMixin, TestCase):


### PR DESCRIPTION
Based on PR for https://github.com/ByteInternet/drf-oidc-auth/pull/20
But updated with master.

Adds a possibility for users to configure a user endpoint if it cannot
be discovered via OpenID connect provider discovery metadata. Also
provide and error message when none could be found (including user
specified one).

Special thanks to @wiliamsouza